### PR TITLE
remove manual yarn install in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,6 @@ FROM node:8.2-alpine
 ENV HOME=/home/app
 ENV APP_PATH=$HOME/listing-frontend
 
-#Install yarn
-ENV YARN_VERSION 0.27.5
-ADD https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v${YARN_VERSION}.tar.gz /opt/yarn-dir
-RUN cd /opt/ && mv yarn-dir/dist yarn && rmdir yarn-dir
-ENV PATH $PATH:/opt/yarn/bin/
-
 # Copy necessary files for installing dependencies
 COPY yarn.lock package.json $APP_PATH/
 


### PR DESCRIPTION
Hadde problemer med å bygge listing-frontend. Problemet var yarn-relatert, så jeg sammenliknet Dockerfilen med ndla-frontend sin. Den installerer ikke lengre yarn manuelt, men virker som at den følger med node-alpine docker-imaget.
Ut i fra [denne](https://github.com/NDLANO/ndla-frontend/commit/6c4381b5346dff3089db376c7708b8a3e54e26ad#diff-3254677a7917c6c01f55212f86c57fbf) committen virker som om at yarn følger med node-alpine [fom. node 8](https://github.com/mhart/alpine-node/issues/65#issuecomment-305056795), forstår jeg det rett?