### PR TITLE
remove header when oembed

### DIFF
--- a/src/server/routes/defaultRoute.js
+++ b/src/server/routes/defaultRoute.js
@@ -38,6 +38,10 @@ export function defaultRoute(req, res) {
   const paths = req.url.split('/');
   const { abbreviation: locale, messages } = getLocaleObject(paths[1]);
   const userAgentString = req.headers['user-agent'];
+  // Oembed-hack
+  if (paths.find(p => p.includes('listing')) || paths.includes('concepts')) {
+    res.removeHeader('X-Frame-Options');
+  }
 
   if (__DISABLE_SSR__) {
     // eslint-disable-line no-underscore-dangle


### PR DESCRIPTION
Fjerner X-Frame-Options header ved visning av embedbare urler. Burde sikkert løses bedre seinere, men for å få ut versjon før jul holder dette.

Test: `curl -I http://localhost:3000/concepts/548/nb` skal ikkje returnere x-frame-options headeren.