### PR TITLE
2396 Justere css for visning av forklaring i iframe

### DIFF
--- a/src/components/Concept/ConceptPage.jsx
+++ b/src/components/Concept/ConceptPage.jsx
@@ -9,6 +9,7 @@
 import React, { Fragment, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Remarkable } from 'remarkable';
+import styled from "@emotion/styled";
 import {
   NotionDialogContent,
   NotionDialogLicenses,
@@ -33,6 +34,10 @@ import {
   fetchSubjectIds,
 } from '../../containers/Subject/subjectApi';
 import VisualElement from './VisualElement';
+
+const StyledConcept = styled.div`
+    width: 90%;
+  `
 
 const initialArticle = {
   id: '',
@@ -250,7 +255,7 @@ const ConceptPage = ({ t, conceptId, handleClose, inModal, language }) => {
           {conceptBody}
         </NotionDialogWrapper>
       ) : (
-        <>
+        <StyledConcept>
           <NotionHeaderWithoutExitButton title={concept.title} />
           {conceptBody}
           <CreatedBy
@@ -258,7 +263,7 @@ const ConceptPage = ({ t, conceptId, handleClose, inModal, language }) => {
             description={t('createdBy.concept.text')}
             url={`${config.ndlaListingFrontendDomain}/?concept=${conceptId}`}
           />
-        </>
+        </StyledConcept>
       )}
     </OneColumn>
   );

--- a/src/components/Concept/ConceptPage.jsx
+++ b/src/components/Concept/ConceptPage.jsx
@@ -9,7 +9,7 @@
 import React, { Fragment, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Remarkable } from 'remarkable';
-import styled from "@emotion/styled";
+import styled from '@emotion/styled';
 import {
   NotionDialogContent,
   NotionDialogLicenses,
@@ -36,8 +36,8 @@ import {
 import VisualElement from './VisualElement';
 
 const StyledConcept = styled.div`
-    width: 90%;
-  `
+  width: 90%;
+`;
 
 const initialArticle = {
   id: '',


### PR DESCRIPTION
Fixes NDLANO/Issues#2396

Problemet ligger i at iframe har en marg som innholdet ikke tar hensyn til når bredden settes, så la til en styling på `ConceptPage` med 90 % bredde. Ville helst sette `margin: 0` for at den skal være midtstilt på listing, men da kommer det samme problemet at den blir plassert for langt til høyre i iframen. Men det er ikke helt optimalt at den ikke er midtstilt... 

Så hvis noen har en idé for hvordan det kan løses mer optimalt tar jeg i mot med takk!

- [Artikkel i ed med iframe forklaring (øverste er hentet fra now deployment, nederste fra test)](https://ed.test.ndla.no/subject-matter/learning-resource/22729/edit/nb)
- [Fullskjermvisning av forklaring i listing med styling](https://listing-frontend-pr-83.ndla.sh/concepts/603)
- [Gammel fullskjermvisning av forklaring i listing](https://liste.test.ndla.no/concepts/603)