### PR TITLE
enabling both subject and filter and using one common fetch method fo…

### DIFF
--- a/src/api/concept/conceptApi.ts
+++ b/src/api/concept/conceptApi.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import queryString from 'query-string';
 import {
   resolveJsonOrRejectWithError,
   apiResourceUrl,
@@ -25,31 +26,20 @@ export const fetchConcepts = (
   pageSize: number,
   language: string,
   query: string,
-): Promise<ConceptSearchResult[]> =>
-  fetch(
-    `${baseConceptUrl}?sort=title&page=${page}&page-size=${pageSize}&language=${language}&query=${query}&fallback=true`,
-  ).then(resolveJsonOrRejectWithError);
-
-export const fetchConceptsBySubject = (
-  subjectId: number,
-  page: number,
-  pageSize: number,
-  language: string,
-  query: string,
-): Promise<ConceptSearchResult[]> =>
-  fetch(
-    `${baseConceptUrl}?sort=title&subjects=${subjectId}&page=${page}&page-size=${pageSize}&language=${language}&query=${query}&fallback=true`,
-  ).then(resolveJsonOrRejectWithError);
-
-export const fetchConceptsByTags = (
   tags: CommaSeparatedList,
-  page: number,
-  pageSize: number,
-  language: string,
-  query: string,
+  subjects: string,
 ): Promise<ConceptSearchResult[]> =>
   fetch(
-    `${baseConceptUrl}?sort=title&tags=${tags}&page=${page}&page-size=${pageSize}&language=${language}&query=${query}&fallback=true`,
+    `${baseConceptUrl}?${queryString.stringify({
+      sort: 'title',
+      subjects,
+      tags,
+      page,
+      'page-size': pageSize,
+      language,
+      query,
+      fallback: true,
+    })}`,
   ).then(resolveJsonOrRejectWithError);
 
 export const fetchTags = (language: string): Promise<string[]> =>

--- a/src/containers/ListingPage/ListingPage.jsx
+++ b/src/containers/ListingPage/ListingPage.jsx
@@ -34,10 +34,8 @@ import {
 import useQueryParameter from '../../util/useQueryParameter';
 import {
   fetchConcept,
-  fetchConceptsBySubject,
-  fetchTags,
-  fetchConceptsByTags,
   fetchConcepts,
+  fetchTags,
 } from '../../api/concept/conceptApi';
 import { fetchSubjectIds, fetchSubject } from '../Subject/subjectApi';
 import { getLocaleUrls } from '../../util/localeHelpers';
@@ -190,35 +188,19 @@ const ListingPage = ({ t, locale, location, isOembed }) => {
   const getConcepts = async page => {
     const replace = page === 1;
     setLoading(!replace);
-    if (queryParams.subjects.length) {
-      const concepts = await fetchConceptsBySubject(
-        queryParams.subjects,
-        page,
-        PAGE_SIZE,
-        locale,
-        debouncedSearchVal,
-      );
-      handleSetConcepts(concepts.results, concepts.totalCount, replace);
-    } else if (queryParams.filters.length) {
-      const concepts = await fetchConceptsByTags(
-        tags.filter(tag =>
-          queryParams.filters.every(filter => tag.includes(filter)),
-        ),
-        page,
-        PAGE_SIZE,
-        locale,
-        debouncedSearchVal,
-      );
-      handleSetConcepts(concepts.results, concepts.totalCount, replace);
-    } else {
-      const concepts = await fetchConcepts(
-        page,
-        PAGE_SIZE,
-        locale,
-        debouncedSearchVal,
-      );
-      handleSetConcepts(concepts.results, concepts.totalCount, replace);
-    }
+    const concepts = await fetchConcepts(
+      page,
+      PAGE_SIZE,
+      locale,
+      debouncedSearchVal,
+      queryParams.filters.length
+        ? tags.filter(tag =>
+            queryParams.filters.every(filter => tag.includes(filter)),
+          )
+        : [],
+      queryParams.subjects.length ? queryParams.subjects.toString() : undefined,
+    );
+    handleSetConcepts(concepts.results, concepts.totalCount, replace);
     setLoading(false);
   };
 
@@ -280,7 +262,7 @@ const ListingPage = ({ t, locale, location, isOembed }) => {
 
   const handleChangeListFilter = value => {
     setQueryParams({
-      subjects: [],
+      ...queryParams,
       filters: [value],
     });
     setFilterListOpen(false);


### PR DESCRIPTION
…r concepts

Fixes NDLANO/Issues#2307

Skriver om slik at man kan filtrere concepts på fag og filter samtidig.
Slår også sammen de forskjellige fetch metodene til en felles for renere kode og slik at vi bare har en `fetchConcepts` istedenfor tre.

Testing:

1. Velg ett fag (eller flere)
2. Sjekk at du så legge til filter for å få færre resultater