### PR TITLE
getArticles now handles 404 when fetching unpublished articles

### DIFF
--- a/src/components/Concept/ConceptPage.jsx
+++ b/src/components/Concept/ConceptPage.jsx
@@ -133,9 +133,18 @@ const ConceptPage = ({ t, conceptId, handleClose, inModal, language }) => {
 
   const getArticles = async () => {
     if (concept.articleIds) {
-      const articles = await Promise.all(
+      const articles = await Promise.allSettled(
         concept.articleIds.map(articleId => fetchArticle(articleId, language)),
-      );
+      )
+        .then(results => {
+          return results
+            .filter(res => res.status === 'fulfilled')
+            .map(res => res.value);
+        })
+        .catch(e => {
+          console.error('Something went wrong while fetching related articles');
+          return [];
+        });
       setArticles(articles);
     }
   };


### PR DESCRIPTION
Fixes NDLANO/Issues#2469

Dersom en forklaring hadde en upublisert artikkel i listen over relaterte artikler feilet Promise.all fordi fetching av den upubliserte artikkelen feilet. Ved bruk av Promise.allSettled kan man tillate at noen av fetchingene feiler og filtrere disse bort.

Hvordan teste:
1. https://listing-frontend-pr-89.ndla.sh/
2. Åpne en forklaring som inneholder en upublisert artikkel (feks /?concept=764)
3. Se at den viser en liste over alle artikler bortsett fra upubliserte.

Selv har jeg brukt disse til testing:
Upublisert artikkel: https://ed.test.ndla.no/subject-matter/learning-resource/59203/edit/nb
Forklaring: https://ed.test.ndla.no/concept/764/edit/nb