### PR TITLE
Add resize event

### DIFF
--- a/src/components/Concept/ConceptPage.jsx
+++ b/src/components/Concept/ConceptPage.jsx
@@ -251,9 +251,9 @@ const ConceptPage = ({ t, conceptId, handleClose, inModal, language }) => {
         </NotionDialogWrapper>
       ) : (
         <>
+          <PostResizeMessage />
           <NotionHeaderWithoutExitButton title={concept.title} />
           {conceptBody}
-          <PostResizeMessage />
           <CreatedBy
             name={t('createdBy.concept.content')}
             description={t('createdBy.concept.text')}

--- a/src/components/Concept/ConceptPage.jsx
+++ b/src/components/Concept/ConceptPage.jsx
@@ -33,6 +33,7 @@ import {
   fetchSubjectIds,
 } from '../../containers/Subject/subjectApi';
 import VisualElement from './VisualElement';
+import PostResizeMessage from '../PostResizeMessage';
 
 const initialConcept = {
   articleIds: [],
@@ -241,7 +242,7 @@ const ConceptPage = ({ t, conceptId, handleClose, inModal, language }) => {
   }
 
   return (
-    <OneColumn>
+    <OneColumn cssModifier={'iframe'}>
       {inModal ? (
         <NotionDialogWrapper
           title={concept.title}
@@ -252,6 +253,7 @@ const ConceptPage = ({ t, conceptId, handleClose, inModal, language }) => {
         <>
           <NotionHeaderWithoutExitButton title={concept.title} />
           {conceptBody}
+          <PostResizeMessage />
           <CreatedBy
             name={t('createdBy.concept.content')}
             description={t('createdBy.concept.text')}

--- a/src/components/PostResizeMessage.jsx
+++ b/src/components/PostResizeMessage.jsx
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2018-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React from 'react';
+
+class PostResizeMessage extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      width: 0,
+      height: 0,
+    };
+  }
+
+  async componentDidMount() {
+    this.onWatchHeight();
+    this.onResizeReady();
+    window.addEventListener('resize', this.onResizeReady);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.onResizeReady);
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  onResizeReady = () => {
+    if (document.readyState === 'complete') {
+      this.sendResizeToParentWindow();
+    } else {
+      document.onreadystatechange = () => {
+        if (document.readyState === 'complete') {
+          this.sendResizeToParentWindow();
+        }
+      };
+    }
+  };
+
+  onWatchHeight = () => {
+    this.intervalId = setInterval(() => {
+      const container = document.querySelector('o-wrapper--iframe');
+      const height = container ? container.scrollHeight + 35 : 0;
+      if (this.state.height !== height) {
+        this.resizer();
+      }
+    }, 100);
+  };
+
+  sendResizeToParentWindow = () => {
+    const outerWidth =
+      document && document.body
+        ? document.body.getBoundingClientRect().width
+        : 0;
+    if (window.parent && this.state.width !== outerWidth) {
+      this.resizer(outerWidth);
+    }
+  };
+
+  resizer = (width = undefined) => {
+    const container = document.querySelector('o-wrapper--iframe');
+    const height = container ? container.scrollHeight + 35 : 0;
+    const newState = width !== undefined ? { width, height } : { height };
+    this.setState(newState, () =>
+      window.parent.postMessage(
+        {
+          event: 'resize',
+          height,
+        },
+        '*',
+      ),
+    );
+  };
+
+  render() {
+    return null;
+  }
+}
+
+export default PostResizeMessage;

--- a/src/server/routes/oembedRoute.js
+++ b/src/server/routes/oembedRoute.js
@@ -16,7 +16,7 @@ const getOembedObject = (req, title, html) => {
   return {
     data: {
       type: 'rich',
-      provider: 'NDLA Liste',
+      providerName: 'NDLA Liste',
       version: '1.0', // oEmbed version
       height: req.query.height || 800,
       width: req.query.width || 800,

--- a/src/server/routes/oembedRoute.js
+++ b/src/server/routes/oembedRoute.js
@@ -9,7 +9,7 @@
 import { BAD_REQUEST, INTERNAL_SERVER_ERROR } from 'http-status';
 import config from '../../config';
 import { fetchConcept } from '../../api/concept/conceptApi';
-import { isValidListeUrl } from '../../util/listingHelpers';
+import { isListeParamUrl, isListePathUrl } from '../../util/listingHelpers';
 import handleError from '../../util/handleError';
 
 const getOembedObject = (req, title, html) => {
@@ -36,7 +36,13 @@ const getConceptHTMLandTitle = async id => {
 
 const getConceptId = url => {
   const decodedUrl = decodeURIComponent(url);
-  return isValidListeUrl(decodedUrl) ? decodedUrl.split('=')[1] : undefined;
+  if (isListeParamUrl(decodedUrl)) {
+    return decodedUrl.split('=').pop();
+  }
+  if (isListePathUrl(decodedUrl)) {
+    return decodedUrl.split('/').pop();
+  }
+  return undefined;
 };
 
 const oembedConceptRoute = async (req, url) => {

--- a/src/server/routes/oembedRoute.js
+++ b/src/server/routes/oembedRoute.js
@@ -18,7 +18,7 @@ const getOembedObject = (req, title, html) => {
       type: 'rich',
       providerName: 'NDLA Liste',
       version: '1.0', // oEmbed version
-      height: req.query.height || 800,
+      height: req.query.height || 600,
       width: req.query.width || 800,
       title,
       html,

--- a/src/server/routes/oembedRoute.js
+++ b/src/server/routes/oembedRoute.js
@@ -16,6 +16,7 @@ const getOembedObject = (req, title, html) => {
   return {
     data: {
       type: 'rich',
+      provider: 'NDLA Liste',
       version: '1.0', // oEmbed version
       height: req.query.height || 800,
       width: req.query.width || 800,

--- a/src/util/__tests__/listingHelpers-test.js
+++ b/src/util/__tests__/listingHelpers-test.js
@@ -6,7 +6,11 @@
  *
  */
 
-import { mapTagsToFilters, isListeParamUrl, isListePathUrl } from '../listingHelpers';
+import {
+  mapTagsToFilters,
+  isListeParamUrl,
+  isListePathUrl,
+} from '../listingHelpers';
 
 test('split list into filters', () => {
   expect(typeof mapTagsToFilters).toBe('function');

--- a/src/util/__tests__/listingHelpers-test.js
+++ b/src/util/__tests__/listingHelpers-test.js
@@ -6,7 +6,7 @@
  *
  */
 
-import { mapTagsToFilters, isValidListeUrl } from '../listingHelpers';
+import { mapTagsToFilters, isListeParamUrl, isListePathUrl } from '../listingHelpers';
 
 test('split list into filters', () => {
   expect(typeof mapTagsToFilters).toBe('function');
@@ -52,17 +52,17 @@ test('do not split into lists if not two columns', () => {
   expect(mapTagsToFilters(['Teststring'])).toEqual(result);
 });
 
-test('isValidListeUrl correct behavior', () => {
+test('isListeParamUrl correct behavior', () => {
   const urls = new Map();
   urls.set('https://liste.ndla.no/?concept=603', true);
   urls.set('https://liste.test.ndla.no/?concept=603', true);
   urls.set('https://liste.staging.ndla.no/?concept=603', true);
-  urls.set('http://liste.ndla.no/?concept=603', true);
-  urls.set('http://liste.test.ndla.no/?concept=603', true);
-  urls.set('http://liste.staging.ndla.no/?concept=603', true);
-  urls.set('www.liste.ndla.no/?concept=603', true);
-  urls.set('www.liste.test.ndla.no/?concept=603', true);
-  urls.set('www.liste.staging.ndla.no/?concept=603', true);
+  urls.set('http://liste.ndla.no/?concept=603', false);
+  urls.set('http://liste.test.ndla.no/?concept=603', false);
+  urls.set('http://liste.staging.ndla.no/?concept=603', false);
+  urls.set('www.liste.ndla.no/?concept=603', false);
+  urls.set('www.liste.test.ndla.no/?concept=603', false);
+  urls.set('www.liste.staging.ndla.no/?concept=603', false);
   urls.set('liste.ndla.no/?concept=603', true);
   urls.set('liste.test.ndla.no/?concept=603', true);
   urls.set('liste.staging.ndla.no/?concept=603', true);
@@ -73,5 +73,21 @@ test('isValidListeUrl correct behavior', () => {
   urls.set('https://liste.ndla.no/', false);
   urls.set('https://liste..ndla.no/?concept=603', false);
 
-  urls.forEach((value, key) => expect(isValidListeUrl(key)).toBe(value));
+  urls.forEach((value, key) => expect(isListeParamUrl(key)).toBe(value));
+});
+
+test('isListePathUrl correct behavior', () => {
+  const urls = new Map();
+  urls.set('https://liste.ndla.no/concepts/603', true);
+  urls.set('https://liste.test.ndla.no/concepts/603', true);
+  urls.set('https://liste.staging.ndla.no/concepts/603', true);
+  urls.set('http://liste.ndla.no/concepts/603', false);
+  urls.set('www.liste.ndla.no/concepts/603', false);
+  urls.set('liste.ndla.no/concepts/603', true);
+  urls.set('https://liste.ndla.no/concepts/w', false);
+  urls.set('https://liste.ndla.no/concepts/', false);
+  urls.set('https://liste.ndla.no/', false);
+  urls.set('https://liste..ndla.no/concepts/603', false);
+
+  urls.forEach((value, key) => expect(isListePathUrl(key)).toBe(value));
 });

--- a/src/util/listingHelpers.js
+++ b/src/util/listingHelpers.js
@@ -54,7 +54,8 @@ export function mapConceptToListItem(concept) {
   };
 }
 
-export const isValidListeUrl = url =>
-  /^(https?:\/\/)?(www\.)?liste(\.?(test|staging))?\.ndla\.no\/\?concept=\d+$/.test(
-    url,
-  );
+export const isListeParamUrl = url =>
+  /^(https:\/\/)?liste(\.test|\.staging)?\.ndla\.no\/\?concept=\d+$/.test(url);
+
+export const isListePathUrl = url =>
+  /^(https:\/\/)?liste(\.test|\.staging)?\.ndla\.no\/concepts\/\d+$/.test(url);


### PR DESCRIPTION
For å kunne embedde liste-urler i artikler må det både inn resize-event, samt at oembed-endepunkt takler både vanlig og oembed-url. Dette er fordi når vi bruker oembed-proxy fra ed så lagres oembed-urlen i artiklen, men fordi denne urlen ikkje kjennes igjen så vil ikkje embeden vises.

Test
curl https://listing-frontend-pr-92.ndla.sh/oembed\?url\=https://liste.test.ndla.no/\?concept\=100 og curl https://listing-frontend-pr-92.ndla.sh/oembed\?url\=https://liste.test.ndla.no/concepts/100 skal gi samme resultat.