### PR TITLE
Only show subjects with name

### DIFF
--- a/src/containers/ListingPage/ListingPage.tsx
+++ b/src/containers/ListingPage/ListingPage.tsx
@@ -36,7 +36,7 @@ const ListingPage = ({ locale, location, isOembed }: Props): JSX.Element => {
   return (
     <ListingContainer
       isOembed={isOembed}
-      subjects={data.listingPage.subjects}
+      subjects={data.listingPage.subjects.filter(s => s.name)}
       tags={filteredTags}
       filters={filters}
       location={location}


### PR DESCRIPTION
Depends on https://github.com/NDLANO/graphql-api/pull/165

Viser kun fram fag som har navn, då dei andre filtreres ut i graphql.

Test:
1. Kjør graphql lokalt
2. Kjør denne med `yarn start-with-local-graphql`
3. Forklaringer skal vise, og eksisterende fag vises i filterboksen.