### PR TITLE
i18next implementert -test

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@ndla/core": "^0.6.39",
     "@ndla/error-reporter": "^0.4.17",
     "@ndla/forms": "^0.4.40",
-    "@ndla/i18n": "^0.5.3",
+    "@ndla/i18n": "^0.5.4",
     "@ndla/icons": "^0.7.7",
     "@ndla/licenses": "^0.6.51",
     "@ndla/listview": "^0.4.58",

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -11,12 +11,13 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { ApolloProvider } from '@apollo/client';
-import { IntlProvider } from '@ndla/i18n';
-
+import { IntlProvider, I18nextProvider} from '@ndla/i18n';
+import i18n from './i18n2'
 import { createApolloClient } from './util/apiHelpers';
 import { getLocaleObject, isValidLocale } from './i18n';
 import configureStore from './configureStore';
 import App from './containers/App/App';
+
 
 const initialState = window.initialState;
 const localeString = initialState.locale;
@@ -43,6 +44,8 @@ const client = createApolloClient(locale.abbreviation);
 
 const renderApp = () =>
   ReactDOM.render(
+    <I18nextProvider i18n={i18n}>
+
     <ApolloProvider client={client}>
       <Provider store={store}>
         <IntlProvider locale={locale.abbreviation} messages={locale.messages}>
@@ -51,7 +54,8 @@ const renderApp = () =>
           </BrowserRouter>
         </IntlProvider>
       </Provider>
-    </ApolloProvider>,
+    </ApolloProvider>
+    </I18nextProvider>,
     document.getElementById('root'),
   );
 

--- a/src/components/Concept/ConceptPage.jsx
+++ b/src/components/Concept/ConceptPage.jsx
@@ -19,7 +19,7 @@ import {
   NotionDialogWrapper,
   NotionHeaderWithoutExitButton,
 } from '@ndla/notion';
-import { injectT } from '@ndla/i18n';
+import { withTranslation } from '@ndla/i18n';
 import Modal, { ModalBody, ModalCloseButton, ModalHeader } from '@ndla/modal';
 import Button from '@ndla/button';
 import Tabs from '@ndla/tabs';
@@ -229,4 +229,4 @@ ConceptPage.propTypes = {
   language: PropTypes.string.isRequired,
 };
 
-export default injectT(ConceptPage);
+export default withTranslation()(ConceptPage);

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import styled from '@emotion/styled';
-import { injectT } from '@ndla/i18n';
+import { withTranslation } from '@ndla/i18n';
 import { Footer, FooterText, EditorName } from '@ndla/ui';
 
 import { getLocale } from '../containers/Locale/localeSelectors';
@@ -44,4 +44,4 @@ const mapStateToProps = state => ({
   locale: getLocale(state),
 });
 
-export default connect(mapStateToProps)(injectT(FooterWrapper));
+export default withTranslation()(connect(mapStateToProps)(FooterWrapper));

--- a/src/containers/App/App.jsx
+++ b/src/containers/App/App.jsx
@@ -16,7 +16,7 @@ import { connect } from 'react-redux';
 import styled from '@emotion/styled';
 import Helmet from 'react-helmet';
 import { PageContainer } from '@ndla/ui';
-import { injectT } from '@ndla/i18n';
+import { withTranslation } from '@ndla/i18n';
 
 import { getLocale } from '../Locale/localeSelectors';
 import ListingPage from '../ListingPage/ListingPage';
@@ -30,9 +30,27 @@ const StyledPageWrapper = styled.div`
   justify-content: space-between;
 `;
 
-const App = ({ locale, t }) => {
+const App = ({ locale, t, i18n}) => {
+  const languages = i18n.options.supportedLngs
+
   return (
     <PageContainer>
+        {languages.map(key => (
+    <li key={key}>
+      {key === i18n.language ? (
+        <span>{t(`languages.${key}`)}</span>
+      ) : (
+        <button
+         
+          onClick={() => {
+            i18n.changeLanguage(key);
+          }}
+          aria-label={t(`changeLanguage.${key}`)}>
+          {t(`languages.${key}`)}
+        </button>
+      )}
+    </li>
+  ))}
       <StyledPageWrapper>
         <Helmet
           title="NDLA"
@@ -85,4 +103,4 @@ const mapStateToProps = state => ({
   locale: getLocale(state),
 });
 
-export default connect(mapStateToProps)(injectT(App));
+export default withTranslation()(connect(mapStateToProps)(App));

--- a/src/containers/ListingPage/ListingView.tsx
+++ b/src/containers/ListingPage/ListingView.tsx
@@ -16,7 +16,7 @@ import Downshift, {
 import styled from '@emotion/styled';
 import { css, SerializedStyles } from '@emotion/core';
 import { colors, fonts, spacing } from '@ndla/core';
-import { injectT, tType } from '@ndla/i18n';
+import { withTranslation, tType } from '@ndla/i18n';
 // @ts-ignore
 import ListView from '@ndla/listview';
 import {
@@ -167,10 +167,10 @@ interface Props {
   handleChangeFilters: (key: string, values: string[]) => void;
   location: Location;
   locale: string;
+  i18n: any,
 }
 
 const ListingView = ({
-  t,
   isOembed,
   loading,
   showLoadMore,
@@ -194,11 +194,14 @@ const ListingView = ({
   handleChangeFilters,
   location,
   locale,
+  t,
+  i18n
 }: Props & tType): JSX.Element => {
   const [filterSearchValue, setFilterSearchValue] = useState('');
   const [currentListFilters, setCurrentListFilters] = useState<string[]>([]);
   const [detailedItem, setDetailedItem] = useState(null);
   const [viewStyle, setViewStyle] = useState<ViewStyle>('grid');
+  console.log("i18n språk:", i18n.options.supportedLngs)
 
   const handleStateChangeListFilter = (
     changes: StateChangeOptions<string>,
@@ -432,4 +435,4 @@ const ListingView = ({
   );
 };
 
-export default injectT(ListingView);
+export default withTranslation()(ListingView);

--- a/src/i18n2.ts
+++ b/src/i18n2.ts
@@ -1,0 +1,44 @@
+import { i18n } from '@ndla/i18n';
+import { messagesNB, messagesEN, messagesNN } from '@ndla/ui';
+// @ts-ignore
+import nb from './phrases/phrases-nb';
+// @ts-ignore
+import nn from './phrases/phrases-nn';
+// @ts-ignore
+import en from './phrases/phrases-en';
+
+i18n.addResourceBundle('en', 'translation', en, true, false);
+i18n.addResourceBundle('nn', 'translation', nn, true, false);
+i18n.addResourceBundle('nb', 'translation', nb, true, false);
+i18n.addResourceBundle('en', 'translation', messagesEN, true, false);
+i18n.addResourceBundle('nn', 'translation', messagesNN, true, false);
+i18n.addResourceBundle('nb', 'translation', messagesNB, true, false);
+
+//change this to add/remove languages
+export const languages = ['nn', 'nb', "en"];
+
+
+export const isValidLanguage = (lng: string): boolean =>
+  languages.includes(lng);
+
+  
+i18n.init({
+  supportedLngs: languages,
+  debug: true,
+});
+
+i18n.on('languageChanged', function(language:string) {
+  if (typeof document != 'undefined') {
+    document.documentElement.lang = language;
+  }
+  if (typeof window != 'undefined') {
+    const paths: string[] = window.location.pathname.split('/');
+    const basename = isValidLanguage(paths[1] as string) ? `${paths[1]}` : '';
+    if (!(basename === '' && language === 'nb')) {
+      const { search } = window.location;
+      window.history.replaceState({}, 'NDLA', `/${language}/${search}`);
+    }
+  }
+  console.log("i18n blir iniitialisert i listing-frontend")
+});
+export default i18n;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,6 +1043,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.14.5", "@babel/runtime@^7.14.6":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -1492,16 +1499,19 @@
     "@ndla/util" "^0.4.7"
     lodash "^4.17.20"
 
-"@ndla/i18n@^0.5.3":
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/@ndla/i18n/-/i18n-0.5.3.tgz#087b9e54173314c3f090332e8b60a93c8d71e688"
-  integrity sha512-Ccefi+TErRji4fUFmnV/imwzw4KbXDQgwBRkTpl/mfGs8suynNqfnHKZuKJU1VlSqACzkGm/Ai+p93+vaiLN4Q==
+"@ndla/i18n@^0.5.3", "@ndla/i18n@^0.5.4":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@ndla/i18n/-/i18n-0.5.4.tgz#20206d8dc9722dd58798a6073c730793e9481bb5"
+  integrity sha512-eh7+tbrfc53+l48UAvvVnoxynQomp+EhLeUITSk731lqZI64A9jPuUnOe7JXtVvQxgFnj+pp+gtaGv+s/MULdQ==
   dependencies:
     "@types/hoist-non-react-statics" "^3.3.1"
     hoist-non-react-statics "^3.3.0"
+    i18next "^20.3.1"
+    i18next-browser-languagedetector "^6.1.1"
     intl-format-cache "^4.3.1"
     intl-messageformat "5.4.3"
     invariant "^2.2.3"
+    react-i18next "^11.11.0"
 
 "@ndla/icons@^0.7.7":
   version "0.7.7"
@@ -6641,6 +6651,13 @@ html-minifier-terser@^5.0.1:
     relateurl "^0.2.7"
     terser "^4.6.3"
 
+html-parse-stringify@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
+  integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
+  dependencies:
+    void-elements "3.1.0"
+
 html-react-parser@^0.10.3:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-0.10.5.tgz#d05e3efd8ffaff692007b99b5b7d54f05a6c5f37"
@@ -6772,6 +6789,20 @@ human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
+
+i18next-browser-languagedetector@^6.1.1:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.1.2.tgz#68565a28b929cbc98ab6a56826ef2faf0e927ff8"
+  integrity sha512-YDzIGHhMRvr7M+c8B3EQUKyiMBhfqox4o1qkFvt4QXuu5V2cxf74+NCr+VEkUuU0y+RwcupA238eeolW1Yn80g==
+  dependencies:
+    "@babel/runtime" "^7.14.6"
+
+i18next@^20.3.1:
+  version "20.3.2"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-20.3.2.tgz#5195e76b9e0848a1c198001bf6c7fc72995a55f1"
+  integrity sha512-e8CML2R9Ng2sSQOM80wb/PrM2j8mDm84o/T4Amzn9ArVyNX5/ENWxxAXkRpZdTQNDaxKImF93Wep4mAoozFrKw==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
@@ -11019,6 +11050,14 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
+react-i18next@^11.11.0:
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.11.0.tgz#2f7c6cb4f81f94d1728a02d60e4bb5216709f942"
+  integrity sha512-p1jHmoyJgDFQmyubUEjrx6kCsr1izW/C8i9pOiJy+9lJqLYwNA8sElVplm0VAnop3kH68edT0/g3wB3UvAcRCQ==
+  dependencies:
+    "@babel/runtime" "^7.14.5"
+    html-parse-stringify "^3.0.1"
+
 react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -13522,6 +13561,11 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+void-elements@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
+  integrity sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Har problem med å dele i18n instansen mellom komponentene i frontend-packages og listing-frontend.

`@ndla-i18n` er publisert og skal ikkje trengast å køyrast lokalt for å teste. I `@ndla-i18n` blir i18next initialisert og exportert saman med alle funksjonar me treng fra i18next biblioteka. 

I `i18n2.ts` i listing-frontend så får i18n instansen oversettingsfiler og ei liste med supported languages. Dette er info me ønsker å eigendefinere for kvar enkelt frontend.

Deretter blir denne instansen sendt i ein provider i `client.tsx`. Komponentane hentar ut t-funksjonen og i18n-instansen ved hjelp av useTranslation (hook ) eller withTranslation(HOC).  

**Korleis teste:**
- Kjør denne versjonen av listing frontend. Den har knappar øverst på sida som byttar språk ved hjelp av i18next instansen. 
- Link  listing-frontend opp mot ndla ui. Implementer i18next i  ein komponent  (f.eks languageselector) ved å bruke useTranslation hook importert frå `@ndla/i18n`. 

**Det eg vil skal skje:**
  - Alle komponentar i listing-frontend pluss den du har endra på  i ndla/ui skal bytte språk ved å klikke på knappane på toppen av sida.
  
  (søkeresulatet skal ikkje skifte språk då det ikkje er implementert)

**Det som skjer:**
  - komponentane i listing-frontend blir oversatt, men ikkje dei i `@ndla/ui` eller andre pakkar. 
  - Om ein linkar `@ndla/i18n` til listing-frontend så fungerar ting slik det skal.
  
  Det ser ut som komponentante i @ndla/ui ikkje får med seg oversettingsfilene og lista med språk - altså dei brukar den 
 instansen som først blir initialisert i `@ndla/i18n`.
  
  Alt fungerar når ein linkar listing-frontend opp mot` @ndla/i18n`.
