### PR TITLE
TS to JS import handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+build

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/webpack-env": "^1.16.0",
     "@typescript-eslint/eslint-plugin": "^4.8.2",
     "@typescript-eslint/parser": "^4.8.2",
+    "@types/remarkable":"^2.0.3",
     "babel-jest": "^25.1.0",
     "babel-loader": "^8.0.6",
     "babel-preset-razzle": "4.0.2",

--- a/src/api/concept/conceptApi.ts
+++ b/src/api/concept/conceptApi.ts
@@ -11,7 +11,6 @@ import {
   resolveJsonOrRejectWithError,
   apiResourceUrl,
   fetch,
-  // @ts-ignore
 } from '../../util/apiHelpers';
 import { ConceptSearchResult } from './conceptApiInterfaces';
 

--- a/src/api/oembed-proxy/oembedProxyApi.ts
+++ b/src/api/oembed-proxy/oembedProxyApi.ts
@@ -10,7 +10,6 @@ import {
   resolveJsonOrRejectWithError,
   apiResourceUrl,
   fetch,
-  // @ts-ignore
 } from '../../util/apiHelpers';
 import { OembedProxyApiType } from './oembedProxyApiInterfaces';
 

--- a/src/components/Concept/VisualElement.tsx
+++ b/src/components/Concept/VisualElement.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// @ts-ignore
 import Image from '@ndla/ui/lib/Image';
 import { VisualElementType } from '../../interfaces';
 

--- a/src/containers/ListingPage/ListingContainer.tsx
+++ b/src/containers/ListingPage/ListingContainer.tsx
@@ -8,9 +8,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useQuery } from '@apollo/client';
 import ListingView from './ListingView';
-// @ts-ignore
 import useQueryParameter from '../../util/useQueryParameter';
-// @ts-ignore
 import { getTagsParameter } from '../../util/listingHelpers';
 import { conceptSearchQuery } from '../../queries';
 import {

--- a/src/containers/ListingPage/ListingPage.tsx
+++ b/src/containers/ListingPage/ListingPage.tsx
@@ -9,11 +9,8 @@ import React from 'react';
 import { useQuery } from '@apollo/client';
 // @ts-ignore
 import { Spinner } from '@ndla/ui';
-
-// @ts-ignore
 import { mapTagsToFilters, filterTags } from '../../util/listingHelpers';
 import ListingContainer from './ListingContainer';
-// @ts-ignore
 import NotFoundPage from '../NotFoundPage/NotFoundPage';
 import { listingPageQuery } from '../../queries';
 import { Location, ListingPageType } from '../../interfaces';

--- a/src/containers/ListingPage/ListingView.tsx
+++ b/src/containers/ListingPage/ListingView.tsx
@@ -7,7 +7,6 @@
  */
 import React, { ChangeEvent, useState } from 'react';
 import Helmet from 'react-helmet';
-// @ts-ignore
 import { Remarkable } from 'remarkable';
 import Downshift, {
   StateChangeOptions,
@@ -17,7 +16,6 @@ import styled from '@emotion/styled';
 import { css, SerializedStyles } from '@emotion/core';
 import { colors, fonts, spacing } from '@ndla/core';
 import { injectT, tType } from '@ndla/i18n';
-// @ts-ignore
 import ListView from '@ndla/listview';
 import {
   // @ts-ignore
@@ -28,26 +26,17 @@ import {
   // @ts-ignore
   MastheadItem,
   CreatedBy,
+  // @ts-ignore
+  Spinner,
 } from '@ndla/ui';
-// @ts-ignore
 import { DropdownInput, DropdownMenu } from '@ndla/forms';
-// @ts-ignore
 import { ChevronDown, Search } from '@ndla/icons/lib/common';
-// @ts-ignore
 import Button from '@ndla/button';
-// @ts-ignore
-import { Spinner } from '@ndla/ui';
-// @ts-ignore
 import { getLocaleUrls } from '../../util/localeHelpers';
-// @ts-ignore
 import { mapConceptToListItem } from '../../util/listingHelpers';
-// @ts-ignore
 import ConceptPage from '../../components/Concept/ConceptPage';
-// @ts-ignore
 import Footer from '../../components/Footer';
-// @ts-ignore
 import CopyTextButton from '../../components/CopyTextButton';
-// @ts-ignore
 import config from '../../config';
 import { Location, Filter, Concept, ListItem, Subject } from '../../interfaces';
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2021-present, NDLA.
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+Declaring a global .d.ts file for every js import in the project structure in order for Typescript compilation to go smoothly. 
+Utilizing this will not affect the compilation/checks for the pure TS components only helps handle JS imports. 
+When typescript files are compiled the compiler will look for a .d.ts file for types for the corresponding import/file, since js files don't have
+these files it crash and complain that there is no given type any for the specific import/js-file. 
+*/
+declare module '*';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1892,6 +1892,11 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/highlight.js@^9.7.0":
+  version "9.12.4"
+  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.4.tgz#8c3496bd1b50cc04aeefd691140aa571d4dbfa34"
+  integrity sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==
+
 "@types/history@*":
   version "4.7.8"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
@@ -2045,6 +2050,14 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/remarkable@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/remarkable/-/remarkable-2.0.3.tgz#ba2e5edada8f0fe64c658beb2127e06ac0b9c1c8"
+  integrity sha512-QQUBeYApuHCNl9Br6ZoI3PlKmwZ69JHrlJktJXnjxobia9liZgsI70fm8PnCqVFAcefYK+9PGzR5L/hzCslNYQ==
+  dependencies:
+    "@types/highlight.js" "^9.7.0"
+    highlight.js "^9.7.0"
 
 "@types/scheduler@*":
   version "0.16.1"
@@ -6543,6 +6556,11 @@ highlight.js@^10.1.1, highlight.js@~10.7.0:
   version "10.7.2"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.2.tgz#89319b861edc66c48854ed1e6da21ea89f847360"
   integrity sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==
+
+highlight.js@^9.7.0:
+  version "9.18.5"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
+  integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
 
 history@^4.7.2, history@^4.9.0:
   version "4.10.1"


### PR DESCRIPTION
Samme feil som var i ndla-frontend. Hadde ikke en global type fil for `js` filer. La til global.d.ts for å håndtere imports, fjernet så x antall ts-ignore kommentarer som var unødvendige. Merket også at det ikke var noen dockerignore fil, så hele mappa ble sendt til docker ved build, la til samme dockerignore som i ndla-frontend. 

- Fikset global type import for js filer i ts
- Fikset context load
- Fjernet unødvendige ignores