### PR TITLE
Fix vercel/now deployments

### DIFF
--- a/now.json
+++ b/now.json
@@ -7,7 +7,7 @@
     },
     {
       "src": "build/server.js",
-      "use": "@now/node-server"
+      "use": "@vercel/node"
     }
   ],
   "routes": [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/webpack-env": "^1.16.0",
     "@typescript-eslint/eslint-plugin": "^4.8.2",
     "@typescript-eslint/parser": "^4.8.2",
-    "@types/remarkable":"^2.0.3",
+    "@types/remarkable": "^2.0.3",
     "babel-jest": "^25.1.0",
     "babel-loader": "^8.0.6",
     "babel-preset-razzle": "4.0.2",


### PR DESCRIPTION
Det eeeegentlige problemet kunne fikses rett på vercel konsollen (Var en switch som valgte node v12 og det matcha dårlig med 14 i package json), men `@now/node-server` er deprecated så endrer den også.