### PR TITLE
Added oembed-transform for subject-url. Needed for ed.

### DIFF
--- a/src/server/routes/oembedRoute.js
+++ b/src/server/routes/oembedRoute.js
@@ -79,6 +79,17 @@ const oembedListingRoute = (req, url) => {
   return getOembedObject(req, filter, html);
 };
 
+const oembedSubjectsRoute = (req, url) => {
+  const decodedUrl = decodeURIComponent(url);
+  // This currently only supports one subject
+  const subjects = decodedUrl.split('subjects[]=')[1];
+  const html = `<iframe aria-label="${'decodedTitle'}" src="${
+    config.ndlaListingFrontendDomain
+  }/listing?subjects[]=${subjects}" frameborder="0" allowFullscreen="" />`;
+
+  return getOembedObject(req, subjects, html);
+};
+
 export async function oembedRoute(req) {
   const { url } = req.query;
 
@@ -93,6 +104,8 @@ export async function oembedRoute(req) {
     return await oembedConceptRoute(req, url);
   } else if (url.includes('filters')) {
     return oembedListingRoute(req, url);
+  } else if (url.includes('subjects')) {
+    return oembedSubjectsRoute(req, url);
   } else {
     return {
       status: BAD_REQUEST,


### PR DESCRIPTION
Det var ikkje nok å legge til støtte for subjects. Oembed-endepunktet måtte oppdateres også.

Test:
Kopier en url fra liste.test.ndla.no med valgt subject. Denne må du teste mot pr-installasjon ved å kjøre lokalt: 
`curl https://listing-frontend-pr-118.ndla.sh/oembed?url=<kopiert-url>` 
Du skal få en json tilbake og ikkje Bad request.