### PR TITLE
VisualElement on ConceptPage no longer renders in size 0px*0px

### DIFF
--- a/src/components/Concept/ConceptPage.jsx
+++ b/src/components/Concept/ConceptPage.jsx
@@ -7,6 +7,7 @@
  */
 
 import React, { Fragment, useEffect, useState } from 'react';
+import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import { Remarkable } from 'remarkable';
@@ -162,11 +163,17 @@ const ConceptPage = ({
     </Modal>
   );
 
+  const StyledVisualElementContainer = styled.div`
+    flex-grow: 1;
+  `;
+
   const conceptBody = (
     <>
       <NotionDialogContent>
         {concept.visualElement ? (
-          <VisualElement visualElement={concept.visualElement} />
+          <StyledVisualElementContainer>
+            <VisualElement visualElement={concept.visualElement} />
+          </StyledVisualElementContainer>
         ) : null}
         <NotionDialogText>{renderMarkdown(concept.content)}</NotionDialogText>
       </NotionDialogContent>


### PR DESCRIPTION
Fixes NDLANO/Issues#2670

Fikser et problem der SVG-er i noen tilfeller ble vist i størrelse 0px*0px. Usikker på nøyaktig grunn, men var på grunn av forskjeller i måten svg-ene var bygd opp. Løsningen ble å legge en div utenpå med `flex-grow: 1`. SVG-en fyller da hele bredden.

Artikkel som ikke fungerer:
https://liste.ndla.no/concepts/1197


Hvordan teste:
1. Åpne PR-instans
2. Sjekk om den samme artikkelen nå fungerer: https://listing-frontend-pr-119.ndla.sh/concepts/1197
3. Sjekk om andre artikler fortsatt vises riktig
