### PR TITLE
Fix translation overwrite

### DIFF
--- a/src/i18n2.ts
+++ b/src/i18n2.ts
@@ -13,9 +13,9 @@ export const initializeI18n = (
   history: History,
 ): void => {
   i18n.options.supportedLngs = ['nb', 'nn'];
-  i18n.addResourceBundle('en', 'translation', en, false, false);
-  i18n.addResourceBundle('nb', 'translation', nb, false, false);
-  i18n.addResourceBundle('nn', 'translation', nn, false, false);
+  i18n.addResourceBundle('en', 'translation', en, true, true);
+  i18n.addResourceBundle('nb', 'translation', nb, true, true);
+  i18n.addResourceBundle('nn', 'translation', nn, true, true);
 
   i18n.on('languageChanged', function(language) {
     if (typeof document != 'undefined') {


### PR DESCRIPTION
Nåværende konfigurasjon overskriver eksisterende top-level oversettelsesnøkler dersom de redefineres. 