### PR TITLE
Hotfix: Feilrettinger på apa-referanser

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@ndla/error-reporter": "^1.0.8",
     "@ndla/forms": "^1.1.0",
     "@ndla/icons": "^1.6.0",
-    "@ndla/licenses": "^2.2.0",
+    "@ndla/licenses": "^3.0.0",
     "@ndla/listview": "^1.1.0",
     "@ndla/modal": "^1.2.0",
     "@ndla/notion": "^1.2.0",

--- a/src/components/LicenseBox.tsx
+++ b/src/components/LicenseBox.tsx
@@ -132,7 +132,10 @@ interface ImageContentProps {
 }
 
 export const ImageContent = ({ images, conceptId }: ImageContentProps) => {
-  const { t } = useTranslation();
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation();
   const AnchorButton = StyledButton.withComponent('a');
   return (
     <>
@@ -167,6 +170,7 @@ export const ImageContent = ({ images, conceptId }: ImageContentProps) => {
                       image.copyright?.license?.license,
                       config.ndlaFrontendDomain,
                       t,
+                      language,
                     )}
                   />
                   <AnchorButton

--- a/yarn.lock
+++ b/yarn.lock
@@ -2146,6 +2146,14 @@
     "@ndla/core" "^1.0.0"
     "@ndla/icons" "^1.6.0"
 
+"@ndla/licenses@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@ndla/licenses/-/licenses-3.0.0.tgz#8156fcfc73328a142ebd3dc6399894a12d9043a8"
+  integrity sha512-eOdo6i62oNxbBnFzlNDJu26jtIF50sHcCE1Z7qPxawPHR2Y0eDv7HRl+dFDjL80sXcwXsRKWIZ+FD0zFMjENvQ==
+  dependencies:
+    "@ndla/core" "^1.0.0"
+    "@ndla/icons" "^1.6.0"
+
 "@ndla/listview@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@ndla/listview/-/listview-1.1.0.tgz#33e75637eafa0f1e440f97a3938673971b1c46cc"


### PR DESCRIPTION
Ingen store endringer her. Har oppdatert bruken av apa-funksjoner fra ndla/licenses og med det kommer noen endringer i kopieringstekst.

Følgende er nytt i tekst for kopiering under bilder i "regler for bruk":
- Både opphavere og rettighetshavere listes opp dersom begge deler finnes.
- NDLA er fjernet fra før url.
- Lisens vises nå uten bindestrek etter CC og før versjonsnummer (4.0)
- Personer/organisasjoner skilles med komma