### PR TITLE
Add empty HelmetProvider to empty server render to avoid crash

### DIFF
--- a/src/server/routes/defaultRoute.tsx
+++ b/src/server/routes/defaultRoute.tsx
@@ -75,6 +75,11 @@ export async function defaultRoute(req: Request, res: Response) {
 
   const client = createApolloClient(locale);
   const helmetContext = {};
+  const clientComponent = (
+    <HelmetProvider context={helmetContext}>
+      <></>
+    </HelmetProvider>
+  );
 
   if (disableSSR(req)) {
     // eslint-disable-line no-underscore-dangle
@@ -84,6 +89,7 @@ export async function defaultRoute(req: Request, res: Response) {
       initialProps: {
         locale,
       },
+      component: clientComponent,
       client,
       helmetContext,
     });


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3119
Legger til en tom `HelmetProvider` som `component` for å unngå at uthenting av helmet-contexten ikke returnerer undefined.

Hvordan teste: Sjekk at siden kan lastes inn med `?disableSSR=true`, samt at meta-tags i head ser riktig ut.